### PR TITLE
fix(ori-2357): implement approve collection delegate

### DIFF
--- a/original_metaplex_python/metaplex/nft_module/authorization.py
+++ b/original_metaplex_python/metaplex/nft_module/authorization.py
@@ -5,6 +5,8 @@ from typing import Optional, Union, cast
 from solders.pubkey import Pubkey
 
 from original_metaplex_python.metaplex.nft_module.delegate_input import (
+    MetadataDelegateInputWithData,
+    TokenDelegateInputWithData,
     TokenMetadataDelegateInput,
     parse_token_metadata_delegate_input,
 )
@@ -67,10 +69,11 @@ TokenMetadataAuthority = Union[
 
 
 class AuthorityType(Enum):
-    Metadata = 0
-    MetadataDelegate = 1
-    TokenDelegate = 2
-    Holder = 3
+    None_ = 0
+    Metadata = 1
+    Holder = 2
+    MetadataDelegate = 3
+    TokenDelegate = 4
 
 
 @dataclass
@@ -148,7 +151,10 @@ def parse_token_metadata_authorization(
             type=input.authority.type,
         )
         delegate_output = parse_token_metadata_delegate_input(
-            metaplex, input.mint, delegate_input, input.programs
+            metaplex=metaplex,
+            mint=input.mint,
+            input=cast(MetadataDelegateInputWithData, delegate_input),
+            programs=input.programs,
         )
         delegate_record = delegate_output.delegate_record
         approver = delegate_output.approver
@@ -168,7 +174,10 @@ def parse_token_metadata_authorization(
         )
 
         delegate_output = parse_token_metadata_delegate_input(
-            metaplex, input.mint, delegate_input, input.programs
+            metaplex=metaplex,
+            mint=input.mint,
+            input=cast(TokenDelegateInputWithData, delegate_input),
+            programs=input.programs,
         )
 
         delegate_record = delegate_output.delegate_record

--- a/original_metaplex_python/metaplex/nft_module/delegate_input.py
+++ b/original_metaplex_python/metaplex/nft_module/delegate_input.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Any, Optional, Union, cast
 
 from solders.pubkey import Pubkey
 
@@ -32,10 +32,32 @@ class TokenMetadataDelegateOutput:
     token_account: Optional[Pubkey] = None
 
 
+@dataclass
+class MetadataDelegateInputWithData:
+    delegate: Signer
+    update_authority: Pubkey
+    type: str
+    data: Optional[Any] = None
+    __kind: Optional[Any] = None
+
+
+@dataclass
+class TokenDelegateInputWithData:
+    delegate: Signer
+    owner: Pubkey
+    type: str
+    data: Any
+    __kind: Any
+    token: Optional[Pubkey] = None
+
+
+DelegateInputWithData = Union[MetadataDelegateInputWithData, TokenDelegateInputWithData]
+
+
 def parse_token_metadata_delegate_input(
     metaplex,
     mint: Pubkey,
-    input: TokenMetadataDelegateInput,
+    input: DelegateInputWithData,
     programs: Optional[list[Program]] = None,
 ):
     if hasattr(input, "update_authority"):

--- a/original_metaplex_python/metaplex/nft_module/delegate_type.py
+++ b/original_metaplex_python/metaplex/nft_module/delegate_type.py
@@ -1,5 +1,10 @@
 from enum import Enum
 
+from original_metaplex_python.metaplex.errors.sdk_error import UnreachableCaseError
+from original_metaplex_python.metaplex.nft_module.errors import (
+    DelegateRoleRequiredDataError,
+)
+
 
 class MetadataDelegateRole(Enum):
     AuthorityItem = 0
@@ -19,6 +24,23 @@ class TokenDelegateRole(Enum):
     SaleV1 = 3
     UtilityV1 = 4
     StakingV1 = 5
+
+
+class TokenDelegateType(Enum):
+    StandardV1 = "StandardV1"
+    TransferV1 = "TransferV1"
+    LockedTransferV1 = "LockedTransferV1"
+    SaleV1 = "SaleV1"
+    UtilityV1 = "UtilityV1"
+    StakingV1 = "StakingV1"
+
+
+class MetadataDelegateType(Enum):
+    # AuthorityItemV1 = 'AuthorityItemV1'
+    CollectionV1 = "CollectionV1"
+    # UseV1 = 'UseV1'
+    DataV1 = "DataV1"
+    ProgrammableConfigV1 = "ProgrammableConfigV1"
 
 
 token_delegate_role_map = {
@@ -57,3 +79,30 @@ def get_metadata_delegate_role(type):
 
 def get_metadata_delegate_role_seed(type) -> str:
     return metadata_delegate_seed_map[get_metadata_delegate_role(type)]
+
+
+delegate_custom_data_map = {
+    # Metadata.
+    # AuthorityItemV1: false,
+    "CollectionV1": False,
+    # UseV1: false,
+    "DataV1": False,
+    "ProgrammableConfigV1": False,
+    # Token
+    "StandardV1": True,
+    "TransferV1": True,
+    "SaleV1": True,
+    "UtilityV1": True,
+    "StakingV1": True,
+    "LockedTransferV1": True,
+}
+
+
+def get_default_delegate_args(type):
+    has_custom_data = delegate_custom_data_map[type]
+    if has_custom_data is None:
+        raise UnreachableCaseError(type)
+    if has_custom_data:
+        raise DelegateRoleRequiredDataError(type)
+
+    return {"__kind": type}

--- a/original_metaplex_python/metaplex/nft_module/errors.py
+++ b/original_metaplex_python/metaplex/nft_module/errors.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from solders.pubkey import Pubkey
+
+from original_metaplex_python.metaplex.errors.metaplex_error import (
+    MetaplexError,
+    MetaplexErrorSource,
+)
+
+
+class NftError(MetaplexError):
+    name: str = "NftError"
+
+    def __init__(self, message: str, cause: Optional[Exception] = None):
+        super().__init__(
+            message=message,
+            source=MetaplexErrorSource.PLUGIN,
+            source_details="NFT",
+            cause=cause,
+        )
+
+
+class ParentCollectionMissingError(NftError):
+    name: str = "ParentCollectionMissingError"
+
+    def __init__(self, mint: Pubkey, operation: str):
+        message = (
+            f"You are trying to send the operation [${operation}] which requires the NFT to have a parent "
+            f"collection but that is not the case for the NFT at address [${mint}]. Ensure the NFT you are "
+            f"interacting with has a parent collection."
+        )
+        super().__init__(message)
+
+
+class DelegateRoleRequiredDataError(NftError):
+    name: str = "DelegateRoleRequiredDataError"
+
+    def __init__(self, type):
+        message = (
+            f"You are trying to approve a delegate of type [${type}] but did not provide any data for that "
+            f"role. Please provide the data attribute as the SDK cannot provide a default value for that role."
+        )
+        super().__init__(message)

--- a/original_metaplex_python/metaplex/nft_module/nft_builders_client.py
+++ b/original_metaplex_python/metaplex/nft_module/nft_builders_client.py
@@ -1,10 +1,22 @@
 from typing import Optional
 
 from ..utils.transaction_builder import TransactionBuilderOptions
+from .operations.approve_nft_collection_authority import (
+    ApproveNftCollectionAuthorityBuilderParams,
+    approve_nft_collection_authority_builder,
+)
+from .operations.approve_nft_delegate import (
+    ApproveNftDelegateBuilderParams,
+    approve_nft_delegate_builder,
+)
 from .operations.create_nft import CreateNftBuilderParams, create_nft_builder
 from .operations.create_sft import CreateSftBuilderParams, create_sft_builder
 from .operations.delete_nft import DeleteNftBuilderParams, delete_nft_builder
 from .operations.mint_nft import MintNftBuilderParams, mint_nft_builder
+from .operations.revoke_nft_collection_authority import (
+    RevokeNftCollectionAuthorityBuilderParams,
+    revoke_nft_collection_authority_builder,
+)
 from .operations.transfer_nft import TransferNftBuilderParams, transfer_nft_builder
 from .operations.unverify_nft_collection import (
     UnverifyNftCollectionBuilderParams,
@@ -76,6 +88,20 @@ class NftBuildersClient:
     ):
         return unverify_nft_collection_builder(self.metaplex, input, options)
 
+    def approve_collection_authority(
+        self,
+        input: ApproveNftCollectionAuthorityBuilderParams,
+        options: Optional[TransactionBuilderOptions] = None,
+    ):
+        return approve_nft_collection_authority_builder(self.metaplex, input, options)
+
+    def revoke_collection_authority(
+        self,
+        input: RevokeNftCollectionAuthorityBuilderParams,
+        options: Optional[TransactionBuilderOptions] = None,
+    ):
+        return revoke_nft_collection_authority_builder(self.metaplex, input, options)
+
     def delete(
         self,
         input: DeleteNftBuilderParams,
@@ -89,3 +115,18 @@ class NftBuildersClient:
         options: Optional[TransactionBuilderOptions] = None,
     ):
         return update_nft_builder(self.metaplex, input, options)
+
+    def delegate(
+        self,
+        input: ApproveNftDelegateBuilderParams,
+        options: Optional[TransactionBuilderOptions] = None,
+    ):
+        return approve_nft_delegate_builder(self.metaplex, input, options)
+
+    # TODO_ORIGINAL: Not used yet
+    # def revoke(
+    #         self,
+    #         input: RevokeNftDelegateBuilderParams,
+    #         options: Optional[TransactionBuilderOptions] = None
+    # ):
+    #     return revokeNftDelegateBuilder(self.metaplex, input, options);

--- a/original_metaplex_python/metaplex/nft_module/operations/approve_nft_collection_authority.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/approve_nft_collection_authority.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from solders.pubkey import Pubkey
+
+from original_metaplex_python.metaplex.nft_module.nft_pdas_client import (
+    CollectionAuthorityRecordPdaInput,
+    MintAddressPdaInput,
+)
+from original_metaplex_python.metaplex.types.signer import Signer, get_public_key
+from original_metaplex_python.metaplex.utils.transaction_builder import (
+    InstructionWithSigners,
+    TransactionBuilder,
+    TransactionBuilderOptions,
+)
+from original_metaplex_python.token_metadata.generated.instructions import (
+    ApproveCollectionAuthorityAccounts,
+    approve_collection_authority,
+)
+
+
+@dataclass
+class ApproveNftCollectionAuthorityInput:
+    mint_address: Pubkey
+    collection_authority: Pubkey
+    update_authority: Optional[Signer] = None
+
+
+@dataclass
+class ApproveNftCollectionAuthorityBuilderParams(ApproveNftCollectionAuthorityInput):
+    instruction_key: Optional[str] = None
+
+
+def approve_nft_collection_authority_builder(
+    metaplex,
+    params: ApproveNftCollectionAuthorityBuilderParams,
+    options: Optional[TransactionBuilderOptions | None] = None,
+):
+    programs = options.programs if options else None
+    payer = (
+        options.payer
+        if (options and options.payer)
+        else metaplex.rpc().get_default_fee_payer()
+    )
+
+    mint_address = params.mint_address
+    collection_authority = params.collection_authority
+    update_authority = params.update_authority or metaplex.identity()
+
+    # Programs
+    # system_program = metaplex.programs().get_system(programs)
+    token_metadata_program = metaplex.programs().get_token_metadata(programs)
+
+    # PDAs
+    metadata = (
+        metaplex.nfts()
+        .pdas()
+        .metadata(MintAddressPdaInput(mint=mint_address, programs=programs))
+    )
+    collection_authority_record = (
+        metaplex.nfts()
+        .pdas()
+        .collection_authority_record(
+            CollectionAuthorityRecordPdaInput(
+                mint=mint_address,
+                collection_authority=collection_authority,
+                programs=programs,
+            )
+        )
+    )
+
+    # Building the transaction
+    transaction_builder = TransactionBuilder.make().set_fee_payer(payer)
+
+    transaction_builder.add(
+        InstructionWithSigners(
+            instruction=approve_collection_authority(
+                accounts=ApproveCollectionAuthorityAccounts(
+                    collection_authority_record=collection_authority_record,
+                    new_collection_authority=collection_authority,
+                    update_authority=get_public_key(update_authority),
+                    payer=get_public_key(payer),
+                    metadata=metadata,
+                    mint=mint_address,
+                ),
+                program_id=token_metadata_program.address,
+            ),
+            signers=[payer, update_authority],
+            key=params.instruction_key or "approve_collection_authority",
+        )
+    )
+
+    return transaction_builder

--- a/original_metaplex_python/metaplex/nft_module/operations/approve_nft_delegate.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/approve_nft_delegate.py
@@ -1,0 +1,204 @@
+from dataclasses import dataclass
+from typing import Optional, Union, cast
+
+from solders.pubkey import Pubkey
+from solders.sysvar import INSTRUCTIONS as SYSVAR_INSTRUCTIONS_PUBKEY
+
+from original_metaplex_python.metaplex.nft_module.authorization import (
+    TokenMetadataAuthority,
+    TokenMetadataAuthorityHolder,
+    TokenMetadataAuthorityMetadata,
+    TokenMetadataAuthorization,
+    TokenMetadataAuthorizationDetails,
+    parse_token_metadata_authorization,
+)
+from original_metaplex_python.metaplex.nft_module.delegate_input import (
+    DelegateInputWithData,
+    parse_token_metadata_delegate_input,
+)
+from original_metaplex_python.metaplex.nft_module.delegate_type import (
+    get_default_delegate_args,
+)
+from original_metaplex_python.metaplex.nft_module.models.metadata import is_non_fungible
+from original_metaplex_python.metaplex.nft_module.nft_pdas_client import (
+    MintAddressPdaInput,
+)
+from original_metaplex_python.metaplex.token_module.token_pdas_client import (
+    AssociatedTokenAccountOptions,
+)
+from original_metaplex_python.metaplex.types.signer import Signer, get_public_key
+from original_metaplex_python.metaplex.utils.transaction_builder import (
+    InstructionWithSigners,
+    TransactionBuilder,
+    TransactionBuilderOptions,
+)
+from original_metaplex_python.token_metadata.generated.instructions import (
+    DelegateAccounts,
+    DelegateArgs,
+)
+from original_metaplex_python.token_metadata.generated.instructions import (
+    delegate as delegate_instruction,
+)
+from original_metaplex_python.token_metadata.generated.types import TokenStandardKind
+from original_metaplex_python.token_metadata.generated.types.delegate_args import (
+    CollectionV1,
+    CollectionV1Value,
+)
+
+TOKEN_AUTH_RULES_ID = Pubkey.from_string("auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg")
+
+
+@dataclass
+class NftOrSft:
+    address: Pubkey
+    token_standard: TokenStandardKind
+
+
+@dataclass
+class ApproveNftDelegateInput:
+    nft_or_sft: NftOrSft
+    delegate: DelegateInputWithData
+    authority: Optional[
+        Union[Signer, TokenMetadataAuthorityMetadata, TokenMetadataAuthorityHolder]
+    ] = None
+    authorization_details: Optional[TokenMetadataAuthorizationDetails] = None
+
+
+@dataclass
+class ApproveNftDelegateBuilderParams(ApproveNftDelegateInput):
+    instruction_key: Optional[str] = None
+
+
+def approve_nft_delegate_builder(
+    metaplex,
+    params: ApproveNftDelegateBuilderParams,
+    options: Optional[TransactionBuilderOptions | None] = None,
+):
+    programs = options.programs if options else None
+    payer = (
+        options.payer
+        if (options and options.payer)
+        else metaplex.rpc().get_default_fee_payer()
+    )
+
+    nft_or_sft = params.nft_or_sft
+    authority = params.authority or metaplex.identity()
+    authorization_details = params.authorization_details
+
+    # Programs
+    token_metadata_program = metaplex.programs().get_token_metadata(programs)
+    token_program = metaplex.programs().get_token(programs)
+    # system_program = metaplex.programs().get_system(programs)
+
+    # PDAs
+    metadata = (
+        metaplex.nfts()
+        .pdas()
+        .metadata(MintAddressPdaInput(mint=nft_or_sft.address, programs=programs))
+    )
+
+    master_edition = (
+        metaplex.nfts()
+        .pdas()
+        .master_edition(MintAddressPdaInput(mint=nft_or_sft.address, programs=programs))
+    )
+
+    # New Delegate
+    delegate_output = parse_token_metadata_delegate_input(
+        metaplex=metaplex,
+        mint=nft_or_sft.address,
+        input=params.delegate,
+        programs=programs,
+    )
+    delegate_record = delegate_output.delegate_record
+    delegate = delegate_output.delegate
+    is_token_delegate = delegate_output.is_token_delegate
+
+    # Auth.
+    if hasattr(authority, "__kind"):
+        token_metadata_authority = authority
+    elif hasattr(params.delegate, "owner"):
+        token_metadata_authority = {
+            "__kind": "holder",
+            "owner": authority,
+            "token": metaplex.tokens()
+            .pdas()
+            .associated_token_account(
+                AssociatedTokenAccountOptions(
+                    mint=nft_or_sft.address,
+                    owner=get_public_key(authority),
+                    programs=programs,
+                )
+            ),
+        }
+    else:
+        token_metadata_authority = TokenMetadataAuthorityMetadata(
+            update_authority=cast(Signer, authority),
+        )
+
+    auth = parse_token_metadata_authorization(
+        metaplex,
+        TokenMetadataAuthorization(
+            mint=nft_or_sft.address,
+            authority=cast(TokenMetadataAuthority, token_metadata_authority),
+            authorization_details=authorization_details,
+            programs=programs,
+        ),
+    )
+
+    # TODO_ORIGINAL - We only implement CollectionV1 for our needs:
+    # Original JS code -
+    # const delegateArgsWithoutAuthData: Omit < DelegateArgs, 'authorizationData' > =
+    # params.delegate.data == = undefined
+    # ? getDefaultDelegateArgs(params.delegate.type)
+    # : {
+    #     __kind: params.delegate.type,
+    #     ...params.delegate.data,
+    # };
+
+    delegate_type = (
+        get_default_delegate_args(params.delegate.type)
+        if params.delegate.data is None
+        else {"__kind": params.delegate.type}
+    )
+    match delegate_type["__kind"]:
+        case "CollectionV1":
+            delegate_args_without_auth_data = CollectionV1(
+                value=CollectionV1Value(authorization_data=params.delegate.data)
+            )
+        case _:
+            raise Exception(f"Unsupported delegate type: {params.delegate.type}")
+
+    # Building the transaction
+    transaction_builder = TransactionBuilder.make().set_fee_payer(payer)
+
+    instruction_key = params.instruction_key or "approve_nft_delegate"
+    transaction_builder.add(
+        InstructionWithSigners(
+            instruction=delegate_instruction(
+                accounts=DelegateAccounts(
+                    delegate_record=delegate_record,
+                    delegate=delegate,
+                    metadata=metadata,
+                    master_edition=(
+                        master_edition if is_non_fungible(nft_or_sft) else None
+                    ),
+                    token_record=delegate_record if is_token_delegate else None,
+                    mint=nft_or_sft.address,
+                    token=auth.accounts.token,
+                    authority=auth.accounts.authority,
+                    payer=get_public_key(payer),
+                    sysvar_instructions=SYSVAR_INSTRUCTIONS_PUBKEY,
+                    spl_token_program=token_program.address,
+                    authorization_rules_program=TOKEN_AUTH_RULES_ID,
+                    authorization_rules=auth.accounts.authorization_rules,
+                ),
+                args=DelegateArgs(delegate_args=delegate_args_without_auth_data),
+                program_id=token_metadata_program.address,
+            ),
+            signers=[payer] + auth.signers,
+            key=instruction_key,
+        )
+    )
+
+    return transaction_builder

--- a/original_metaplex_python/metaplex/nft_module/operations/revoke_nft_collection_authority.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/revoke_nft_collection_authority.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from solders.instruction import AccountMeta
+from solders.pubkey import Pubkey
+
+from original_metaplex_python.metaplex.nft_module.nft_pdas_client import (
+    CollectionAuthorityRecordPdaInput,
+    MintAddressPdaInput,
+)
+from original_metaplex_python.metaplex.types.signer import Signer
+from original_metaplex_python.metaplex.utils.transaction_builder import (
+    InstructionWithSigners,
+    TransactionBuilder,
+    TransactionBuilderOptions,
+)
+from original_metaplex_python.token_metadata.generated.instructions import (
+    RevokeCollectionAuthorityAccounts,
+    revoke_collection_authority,
+)
+
+
+@dataclass
+class RevokeNftCollectionAuthorityInput:
+    mint_address: Pubkey
+    collection_authority: Pubkey
+    revoke_authority: Optional[Signer] = None
+
+
+@dataclass
+class RevokeNftCollectionAuthorityBuilderParams(RevokeNftCollectionAuthorityInput):
+    instruction_key: Optional[str] = None
+
+
+def revoke_nft_collection_authority_builder(
+    metaplex,
+    params: RevokeNftCollectionAuthorityBuilderParams,
+    options: Optional[TransactionBuilderOptions | None] = None,
+):
+    programs = options.programs if options else None
+
+    payer = (
+        options.payer
+        if (options and options.payer)
+        else metaplex.rpc().get_default_fee_payer()
+    )
+
+    mint_address = params.mint_address
+    collection_authority = params.collection_authority
+    revoke_authority = params.revoke_authority or metaplex.identity()
+
+    # Get the token metadata program
+    token_metadata_program = metaplex.programs().get_token_metadata(programs)
+
+    # Generate PDAs
+    metadata = (
+        metaplex.nfts()
+        .pdas()
+        .metadata(MintAddressPdaInput(mint=mint_address, programs=programs))
+    )
+
+    collection_authority_record = (
+        metaplex.nfts()
+        .pdas()
+        .collection_authority_record(
+            CollectionAuthorityRecordPdaInput(
+                mint=mint_address,
+                collection_authority=collection_authority,
+                programs=programs,
+            )
+        )
+    )
+
+    # Create the instruction for revoking the collection authority
+    instruction = revoke_collection_authority(
+        accounts=RevokeCollectionAuthorityAccounts(
+            collection_authority_record=collection_authority_record,
+            delegate_authority=collection_authority,
+            revoke_authority=revoke_authority.public_key,
+            metadata=metadata,
+            mint=mint_address,
+        ),
+        program_id=token_metadata_program.address,
+    )
+
+    old_accounts = instruction.accounts
+
+    # Temporary fix. The Shank macro wrongfully ask for the delegateAuthority to be a signer.
+    # https://github.com/metaplex-foundation/metaplex-program-library/pull/639
+    new_delegate_authority_account = AccountMeta(
+        pubkey=collection_authority, is_signer=False, is_writable=True
+    )
+    instruction.accounts = (
+        old_accounts[:1] + [new_delegate_authority_account] + old_accounts[2:]
+    )
+
+    # Building the transaction
+    transaction_builder = TransactionBuilder.make().set_fee_payer(payer)
+
+    transaction_builder.add(
+        InstructionWithSigners(
+            instruction=instruction,
+            signers=[revoke_authority],
+            key=params.instruction_key or "revoke_collection_authority",
+        )
+    )
+
+    return transaction_builder

--- a/original_metaplex_python/metaplex/nft_module/operations/unverify_nft_collection.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/unverify_nft_collection.py
@@ -11,6 +11,7 @@ from original_metaplex_python.metaplex.nft_module.nft_pdas_client import (
 )
 from original_metaplex_python.metaplex.types.signer import Signer, get_public_key
 from original_metaplex_python.metaplex.utils.transaction_builder import (
+    InstructionWithSigners,
     TransactionBuilder,
     TransactionBuilderOptions,
 )
@@ -136,11 +137,11 @@ def unverify_nft_collection_builder(
             TransactionBuilder.make()
             .set_fee_payer(payer)
             .add(
-                {
-                    "instruction": instruction,
-                    "signers": [payer, collection_authority],
-                    "key": params.instruction_key or "unverify_collection",
-                }
+                InstructionWithSigners(
+                    instruction=instruction,
+                    signers=[payer, collection_authority],
+                    key=params.instruction_key or "unverify_collection",
+                )
             )
         )
 
@@ -164,8 +165,8 @@ def unverify_nft_collection_builder(
         TransactionBuilder.make()
         .set_fee_payer(payer)
         .add(
-            {
-                "instruction": unverify(
+            InstructionWithSigners(
+                instruction=unverify(
                     accounts=UnverifyAccounts(
                         authority=get_public_key(collection_authority),
                         delegate_record=delegate_record,
@@ -177,8 +178,8 @@ def unverify_nft_collection_builder(
                     args=UnverifyArgs(verification_args=CollectionV1()),
                     program_id=token_metadata_program.address,
                 ),
-                "signers": [collection_authority],
-                "key": params.instruction_key or "unverify_collection",
-            }
+                signers=[collection_authority],
+                key=params.instruction_key or "unverify_collection",
+            )
         )
     )

--- a/original_metaplex_python/metaplex/nft_module/operations/verify_nft_collection.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/verify_nft_collection.py
@@ -132,11 +132,11 @@ def verify_nft_collection_builder(
             TransactionBuilder.make()
             .set_fee_payer(payer)
             .add(
-                {
-                    "instruction": instruction,
-                    "signers": [payer, collection_authority],
-                    "key": params.instruction_key or "verifyCollection",
-                }
+                InstructionWithSigners(
+                    instruction=instruction,
+                    signers=[payer, collection_authority],
+                    key=params.instruction_key or "verify_collection",
+                )
             )
         )
 

--- a/original_metaplex_python/metaplex/nft_module/operations/verify_nft_creator.py
+++ b/original_metaplex_python/metaplex/nft_module/operations/verify_nft_creator.py
@@ -9,6 +9,7 @@ from original_metaplex_python.metaplex.nft_module.nft_pdas_client import (
 )
 from original_metaplex_python.metaplex.types.signer import Signer, get_public_key
 from original_metaplex_python.metaplex.utils.transaction_builder import (
+    InstructionWithSigners,
     TransactionBuilder,
     TransactionBuilderOptions,
 )
@@ -50,8 +51,8 @@ def verify_nft_creator_builder(
 
     transaction_builder = TransactionBuilder.make().set_fee_payer(payer)
     transaction_builder.add(
-        {
-            "instruction": verify(
+        InstructionWithSigners(
+            instruction=verify(
                 accounts=VerifyAccounts(
                     authority=get_public_key(creator),
                     metadata=metaplex.nfts()
@@ -70,9 +71,9 @@ def verify_nft_creator_builder(
                 ),
                 program_id=token_metadata_program.address,
             ),
-            "signers": [creator],
-            "key": params.instruction_key or "verify_creator",
-        }
+            signers=[creator],
+            key=params.instruction_key or "verify_creator",
+        )
     )
 
     return transaction_builder

--- a/original_metaplex_python/tests/e2e/test_create_with_delegate_flow.py
+++ b/original_metaplex_python/tests/e2e/test_create_with_delegate_flow.py
@@ -1,0 +1,235 @@
+from solana.rpc.api import Client
+from solders.keypair import Keypair
+from solders.transaction_status import TransactionConfirmationStatus
+
+from original_metaplex_python.metaplex import Metaplex
+from original_metaplex_python.metaplex.keypair_identity.plugin import keypair_identity
+from original_metaplex_python.metaplex.nft_module.delegate_input import (
+    MetadataDelegateInputWithData,
+)
+from original_metaplex_python.metaplex.nft_module.operations.approve_nft_delegate import (
+    ApproveNftDelegateBuilderParams,
+)
+from original_metaplex_python.metaplex.nft_module.operations.create_nft import (
+    CreateNftBuilderParams,
+)
+from original_metaplex_python.metaplex.nft_module.operations.transfer_nft import (
+    NftOrSft,
+)
+from original_metaplex_python.metaplex.types.creator import CreatorInput
+from original_metaplex_python.metaplex.utils.transaction_builder import (
+    TransactionBuilderOptions,
+)
+from original_metaplex_python.token_metadata.generated.types.token_standard import (
+    ProgrammableNonFungible,
+)
+
+
+def test_create_with_delegate_flow(project_root):
+    try:
+        with open(f"{project_root}/wallet_secret.txt") as f:
+            secret = f.read()
+            wallet = Keypair.from_base58_string(secret)
+    except FileNotFoundError:
+        raise Exception("Please provide a valid wallet secret file with a private key")
+
+    try:
+        with open(f"{project_root}/wallet_secret_friend.txt") as f:
+            friend_secret = f.read()
+            friend_key_pair = Keypair.from_base58_string(friend_secret)
+    except FileNotFoundError:
+        print(
+            "Please provide a wallet secret file to test transferring NFT to a friend."
+        )
+        return
+
+    # Metaplex Client
+    rpc_url = "https://api.devnet.solana.com"
+
+    ### .use(keypair_identity(wallet) is needed to grab the collection_update_authority later.
+    metaplex = Metaplex.make(Client(rpc_url)).use(keypair_identity(wallet))
+
+    #### CREATE COLLECTION NFT ####
+    collection_nft_builder = (
+        metaplex.nfts()
+        .builders()
+        .create(
+            CreateNftBuilderParams(
+                name="Original NFT Collection",
+                uri="https://mfp2m2qzszjbowdjl2vofmto5aq6rtlfilkcqdtx2nskls2gnnsa.arweave.net/YV-mahmWUhdYaV6q4rJu6CHozWVC1CgOd9NkpctGa2Q",
+                seller_fee_basis_points=0,
+                is_collection=True,
+                update_authority=wallet,
+                mint_authority=wallet,
+                symbol="ORIG",
+                token_owner=wallet.pubkey(),
+            ),
+            options=TransactionBuilderOptions(payer=wallet),
+        )
+    )
+
+    response = metaplex.rpc().send_and_confirm_transaction(collection_nft_builder)
+    signature = response["signature"].value
+    confirm_response = response["confirm_response"]
+    blockhash = response["blockhash"]
+    error = confirm_response.value[0].err
+    confirmation_status = confirm_response.value[0].confirmation_status
+
+    assert signature is not None
+    assert error is None
+    assert confirmation_status == TransactionConfirmationStatus.Finalized
+    assert blockhash is not None
+
+    context = collection_nft_builder.get_context()
+    collection_mint_address = context["mintAddress"]
+    collection_metadata_address = context["metadataAddress"]
+    collection_master_edition_address = context["masterEditionAddress"]
+    collection_token_address = context["tokenAddress"]
+
+    assert collection_mint_address is not None
+    assert collection_metadata_address is not None
+    assert collection_master_edition_address is not None
+    assert collection_token_address is not None
+
+    if error is not None:
+        raise Exception(f"Failed to confirm transaction: {error}")
+
+    print(
+        f"Minted Collection NFT: https://explorer.solana.com/address/{collection_mint_address}?cluster=devnet"
+    )
+    print(f"Tx: https://explorer.solana.com/tx/{signature}?cluster=devnet")
+
+    #### APPROVE FRIEND TO VERIFY NFT ####
+    #### NOT applicable for ProgrammableNonFungible ####
+    # approve_transaction_builder = (
+    #     metaplex.nfts()
+    #     .builders()
+    #     .approve_collection_authority(
+    #         input=ApproveNftCollectionAuthorityBuilderParams(
+    #             mint_address=collection_mint_address,
+    #             update_authority=wallet,
+    #             collection_authority=friend_key_pair.pubkey(),
+    #         ),
+    #         options=TransactionBuilderOptions(
+    #             payer=wallet,
+    #         ),
+    #     )
+    # )
+
+    # We must use the new delegate builder instead
+    approve_delegate_builder = (
+        metaplex.nfts()
+        .builders()
+        .delegate(
+            input=ApproveNftDelegateBuilderParams(
+                nft_or_sft=NftOrSft(
+                    address=collection_mint_address,
+                    token_standard=ProgrammableNonFungible,
+                ),
+                delegate=MetadataDelegateInputWithData(
+                    type="CollectionV1",
+                    delegate=friend_key_pair.pubkey(),
+                    update_authority=wallet.pubkey(),
+                ),
+                authority=wallet,
+            ),
+            options=TransactionBuilderOptions(
+                payer=wallet,
+            ),
+        )
+    )
+
+    response = metaplex.rpc().send_and_confirm_transaction(approve_delegate_builder)
+    signature = response["signature"].value
+    confirm_response = response["confirm_response"]
+    blockhash = response["blockhash"]
+    error = confirm_response.value[0].err
+    confirmation_status = confirm_response.value[0].confirmation_status
+
+    print(
+        f"Approved Collection Delegate: https://explorer.solana.com/address/{collection_mint_address}?cluster=devnet"
+    )
+    print(f"Tx: https://explorer.solana.com/tx/{signature}?cluster=devnet")
+
+    if error:
+        raise Exception(f"Failed to confirm transaction: {error}")
+
+    assert signature is not None
+    assert error is None
+    assert confirmation_status == TransactionConfirmationStatus.Finalized
+    assert blockhash is not None
+
+    #### CREATE NFT ####
+    nft_params = {
+        "name": "Original NFT",
+        "symbol": "ORIG",
+        "seller_fee_basis_points": 500,
+        "creators": [CreatorInput(address=friend_key_pair.pubkey(), share=100)],
+        "metadata": "https://arweave.net/yIgHNXiELgQqW8QIbFM9ibVV37jhvfyW3mFcZGRX-PA",
+        "collection": collection_mint_address,
+    }
+
+    token_owner = Keypair()
+
+    # NOTE - This only works with an approved delegate because we have .use(keypair_identity(wallet))) set above
+    mint_nft_transaction_builder = (
+        metaplex.nfts()
+        .builders()
+        .create(
+            CreateNftBuilderParams(
+                uri=nft_params["metadata"],
+                name=nft_params["name"],
+                seller_fee_basis_points=nft_params["seller_fee_basis_points"],
+                symbol=nft_params["symbol"],
+                creators=nft_params["creators"],
+                is_mutable=True,
+                collection=collection_mint_address,
+                collection_authority=friend_key_pair,
+                collection_authority_is_delegated="metadata_delegate",
+                token_standard=ProgrammableNonFungible,
+                token_owner=token_owner.pubkey(),
+                update_authority=friend_key_pair,
+                mint_authority=friend_key_pair,
+            ),
+            options=TransactionBuilderOptions(
+                payer=friend_key_pair,
+            ),
+        )
+    )
+
+    response = metaplex.rpc().send_and_confirm_transaction(mint_nft_transaction_builder)
+    signature = response["signature"].value
+    confirm_response = response["confirm_response"]
+    blockhash = response["blockhash"]
+    error = confirm_response.value[0].err
+    confirmation_status = confirm_response.value[0].confirmation_status
+
+    assert signature is not None
+    assert error is None
+    assert confirmation_status == TransactionConfirmationStatus.Finalized
+    assert blockhash is not None
+
+    context = mint_nft_transaction_builder.get_context()
+    nft_mint_address = context["mintAddress"]
+    nft_metadata_address = context["metadataAddress"]
+    nft_master_edition_address = context["masterEditionAddress"]
+    nft_token_address = context["tokenAddress"]
+
+    assert nft_mint_address is not None
+    assert nft_metadata_address is not None
+    assert nft_master_edition_address is not None
+    assert nft_token_address is not None
+
+    if error is not None:
+        raise Exception(f"Failed to confirm transaction: {error}")
+
+    print(
+        f"Minted NFT at Mint Address: https://explorer.solana.com/address/{nft_mint_address}?cluster=devnet"
+    )
+    print(
+        f"Token Address: https://explorer.solana.com/address/{nft_token_address}?cluster=devnet"
+    )
+    print(f"Tx: https://explorer.solana.com/tx/{signature}?cluster=devnet")
+
+    if error:
+        raise Exception(f"Failed to confirm transaction: {error}")

--- a/original_metaplex_python/token_metadata/generated/instructions/approve_collection_authority.py
+++ b/original_metaplex_python/token_metadata/generated/instructions/approve_collection_authority.py
@@ -50,7 +50,13 @@ def approve_collection_authority(
     ]
     if remaining_accounts is not None:
         keys += remaining_accounts
-    identifier = b"\xfe\x88\xd0'AB\x1bo"
+
+    # DON 4-Apr-2024 - TODO_ORIGINAL The original code uses this byte string as the identifier, however it doesn't work
+    # and raises an error - "Transaction simulation failed: Error processing Instruction 0: invalid instruction data"
+    #
+    # We use the below descriminator of 23 instead which is taken from the javascript SDK.
+    # identifier = b"\xfe\x88\xd0'AB\x1bo"
+    identifier = bytes([23])
     encoded_args = b""
     data = identifier + encoded_args
     return Instruction(program_id, data, keys)

--- a/original_metaplex_python/token_metadata/generated/instructions/delegate.py
+++ b/original_metaplex_python/token_metadata/generated/instructions/delegate.py
@@ -104,7 +104,9 @@ def delegate(
     ]
     if remaining_accounts is not None:
         keys += remaining_accounts
-    identifier = b"Z\x93K\xb2UX\x04\x89"
+    # TODO_ORIGINAL
+    # identifier = b"Z\x93K\xb2UX\x04\x89"
+    identifier = bytes([44])
     encoded_args = layout.build(
         {
             "delegate_args": args["delegate_args"].to_encodable(),

--- a/original_metaplex_python/token_metadata/generated/instructions/revoke_collection_authority.py
+++ b/original_metaplex_python/token_metadata/generated/instructions/revoke_collection_authority.py
@@ -38,7 +38,13 @@ def revoke_collection_authority(
     ]
     if remaining_accounts is not None:
         keys += remaining_accounts
-    identifier = b"\x1f\x8b\x87\xc6\x1d0\xa0\x9a"
+
+    # DON 4-Apr-2024 - TODO_ORIGINAL The original code uses this byte string as the identifier, however it doesn't work
+    # and raises an error - "Transaction simulation failed: Error processing Instruction 0: invalid instruction data"
+    #
+    # We use the below descriminator of 24 instead which is taken from the javascript SDK.
+    # identifier = b"\x1f\x8b\x87\xc6\x1d0\xa0\x9a"
+    identifier = bytes([24])
     encoded_args = b""
     data = identifier + encoded_args
     return Instruction(program_id, data, keys)


### PR DESCRIPTION
## Why
- We want to delegate collection verification to other EOAs

### How
- Implement the approve nft delegate
- Note: We will need a way to pass the collection_update_authority down the chain (the eoa that deployed the collection), in order to retrieve the delegate (the minter).

### How Has This Been Tested?
- Locally e2e

### Checklist
