### PR TITLE
fix(ori-2364): fix release script ignoring pre-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
             // Getting the release version from the PR source branch
             // Source branch looks like this: release-1.0.0
-            const version = context.payload.pull_request.head.ref.split('-')[1]
+            const version = context.payload.pull_request.head.ref.split('-').slice(1).join('-');
             core.exportVariable('VERSION', version)
 
       - uses: actions/setup-python@v3


### PR DESCRIPTION
## Why
- We use versions like 0.0.1-alpha.1
- This is being ignored by the current script

### How
- Adjust script to grab that from the release branch

### How Has This Been Tested?
- Locally

### Checklist
